### PR TITLE
Minor FreeBSD improvements

### DIFF
--- a/wayland-logout.c
+++ b/wayland-logout.c
@@ -36,6 +36,15 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#ifdef __FreeBSD__
+#include <sys/ucred.h>
+#define ucred xucred
+#define pid cr_pid
+#define SO_PEERCRED LOCAL_PEERCRED
+#undef SOL_SOCKET
+#define SOL_SOCKET SOL_LOCAL
+#endif
+
 // size of field sun_path in struct sockaddr_un
 #define pathlen ((int)sizeof(((struct sockaddr_un *)NULL)->sun_path))
 

--- a/wayland-logout.sh
+++ b/wayland-logout.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# REQUIREMENTS - lsof (not always present)
+# REQUIREMENTS - sockstat or lsof (not always present)
 
 if [ -z "${WAYLAND_DISPLAY}" ]; then
 	printf '%s\n' 'Error: WAYLAND_DISPLAY not set'
@@ -21,7 +21,12 @@ case "${WAYLAND_DISPLAY}" in
 		;;
 esac
 
-WAYLAND_PIDS="$(lsof -t -f -- ${SOCKET_PATH})"
+if hash sockstat 2>/dev/null; then
+	WAYLAND_PIDS="$(sockstat -lu | awk "\$6 == \"${SOCKET_PATH}\" { print \$3 }" | uniq)"
+else
+	WAYLAND_PIDS="$(lsof -t -f -- ${SOCKET_PATH})"
+fi
+
 set -- $WAYLAND_PIDS
 if [ $# -gt 1 ]; then
 	printf '%s\n' 'Error: More than one process has been bound to the socket'


### PR DESCRIPTION
- FreeBSD 13 has `cr_pid`, so it can use C implementation
- lsof is missing on DragonFly but (like FreeBSD and NetBSD) has sockstat

CC @myfreeweb